### PR TITLE
No throw Exception if message is 'Success'

### DIFF
--- a/src/Binlog/Collector/Application/BinlogCollectorApplication.php
+++ b/src/Binlog/Collector/Application/BinlogCollectorApplication.php
@@ -163,8 +163,10 @@ class BinlogCollectorApplication
             $this->logger->info($e->getMessage());
             exit();
         } catch (\Exception $exception) {
-            $this->logger->info("child_index({$child_index} : exception({$exception->getMessage()})");
-            $this->binlog_configuration->exception_handler->triggerException($exception);
+            if ($exception->getMessage() !== 'Success') {
+                $this->logger->info("child_index({$child_index} : exception({$exception->getMessage()})");
+                $this->binlog_configuration->exception_handler->triggerException($exception);
+            }
             exit();
         }
         exit();


### PR DESCRIPTION
exception message "Success"인 경우 불필요한 로깅/Sentry를 발생하지 않도록 수정 했습니다.
확인 부탁드립니다!